### PR TITLE
refactor: Single button for submitting data

### DIFF
--- a/lottie/R/server.R
+++ b/lottie/R/server.R
@@ -115,7 +115,9 @@ if (testing) {
 }
 
 server <- function(input, output, session) {
-    ## Conditions
+    #################################################################################
+    ## Conditions                                                                  ##
+    #################################################################################
     conditions_data <- shiny::reactiveVal(data.frame(
         user = character(),
         date = character(),
@@ -147,22 +149,9 @@ server <- function(input, output, session) {
                 names_from = weather,
                 values_from = present,
                 values_fill = FALSE)
-        print(to_add)
         to_add <- tidy_columns(df = to_add, expected_cols = as.list(conditions_df$code))
-        print(to_add)
         conditions_to_add <- rbind(conditions_data(),  to_add)
         conditions_data(conditions_to_add)
-        RSQLite::dbWriteTable(
-            conn = con,
-            name = "Conditions",
-            unique(conditions_to_add),
-            overwrite = FALSE,
-            append = TRUE
-        )
-        ## @ns-rse 2026-06-08 Debugging...
-        ## print("WHAT HAVE WE GOT IN THE DATABASE Conditions TABLE?")
-        ## query <- "SELECT * FROM Conditions"
-        ## print(RSQLite::dbGetQuery(conn = con, query))
     })
     output$conditions <- shiny::renderTable(
         {
@@ -170,7 +159,10 @@ server <- function(input, output, session) {
         },
         striped = TRUE
     )
-    ## GPS - Extract data and summarise
+
+    #################################################################################
+    ## GPS                                                                         ##
+    #################################################################################
     gps_data <- shiny::observeEvent(input$gpx, {
         ## Load GPX data from input$gpx ($datapath is the path to the temporary file that has been uploaded)
         gpx_data <- xml2::read_xml(input$gpx$datapath)
@@ -263,10 +255,12 @@ server <- function(input, output, session) {
             gps_summary
         },
         striped = TRUE)
-    ## Flock Composition
+
+    #################################################################################
+    ## Flock Composition                                                           ##
+    #################################################################################
     ## Extract ring colours from selection so they can be used to populate the `selectInput(..., choices=)` of the
-    ## `colour_ring_inputs()` function (see https://stackoverflow.com/a/21467399/1444043) second solution using
-    ## shiny::updateSelectInput()
+    ## `colour_ring_inputs()` function
     selected_rings <- shiny::reactive({
         ## We split the returned code using lottie::extract_rings(), this returns rings$leg, rings$top and rings$bottom
         rings <- extract_rings(
@@ -340,20 +334,10 @@ server <- function(input, output, session) {
             composition_data()
         },
         striped = TRUE)
-    ## Add data to SQLite database when the "Submit all composition data" button is pressed
-    shiny::observeEvent(input$submit_composition, {
-        RSQLite::dbWriteTable(
-                     conn = con,
-                     name = "Composition",
-                     composition_data(),
-                     overwrite = FALSE,
-                     append = TRUE)
-        ## @ns-rse 2026-06-02 Debugging...
-        ## print("WHAT HAVE WE GOT IN THE DATABASE Composition TABLE?")
-        ## query <- "SELECT * FROM Composition"
-        ## print(RSQLite::dbGetQuery(conn = con, query))
-    })
-    ## Flock Description
+
+    #################################################################################
+    ## Flock Description                                                           ##
+    #################################################################################
     ## Build a data frame of flock description when the "Submit flock description" button is clicked
    description_data <- shiny::reactiveVal(data.frame(
             date = character(),
@@ -429,20 +413,10 @@ server <- function(input, output, session) {
             description_data()
         },
         striped = TRUE)
-    ## Add data to SQLite database when the "Submit all flock data" button is pressed
-    shiny::observeEvent(input$submit_description, {
-        RSQLite::dbWriteTable(
-                     conn = con,
-                     name = "Description",
-                     unique(description_data()),
-                     overwrite = FALSE,
-                     append = TRUE)
-        ## @ns-rse 2026-06-02 Debugging...
-        ## print("WHAT HAVE WE GOT IN THE DATABASE Description TABLE?")
-        ## query <- "SELECT * FROM Description"
-        ## print(RSQLite::dbGetQuery(conn = con, query))
-    })
-    ## Interactions
+
+    #################################################################################
+    ## Interactions                                                                ##
+    #################################################################################
     ## Build a data frame of interactions when the "Submit interaction" button is clocked
     interactions_data <- shiny::reactiveVal(data.frame(
             date = character(),
@@ -480,14 +454,55 @@ server <- function(input, output, session) {
             interactions_data()
         },
         striped = TRUE)
-    ## Add data to SQLite database when the "Submit all interaction data" button is pressed
-    shiny::observeEvent(input$submit_interactions, {
+
+    #################################################################################
+    ## Database submission                                                         ##
+    #################################################################################
+    ## Add data to SQLite database when the "Submit all data" button is pressed
+    shiny::observeEvent(input$submit_all, {
+        ## GPS data is submitted on file upload
+        ## Conditions/metadata
+        RSQLite::dbWriteTable(
+            conn = con,
+            name = "Conditions",
+            unique(conditions_data()),
+            overwrite = FALSE,
+            append = TRUE
+        )
+        ## @ns-rse 2026-06-08 Debugging...
+        ## print("WHAT HAVE WE GOT IN THE DATABASE Conditions TABLE?")
+        ## query <- "SELECT * FROM Conditions"
+        ## print(RSQLite::dbGetQuery(conn = con, query))
+        ## Composition
         RSQLite::dbWriteTable(
                      conn = con,
-                     name = "Interactions",
-                     unique(interactions_data()),
+                     name = "Composition",
+                     composition_data(),
                      overwrite = FALSE,
                      append = TRUE)
+        ## @ns-rse 2026-06-02 Debugging...
+        ## print("WHAT HAVE WE GOT IN THE DATABASE Composition TABLE?")
+        ## query <- "SELECT * FROM Composition"
+        ## print(RSQLite::dbGetQuery(conn = con, query))
+        ## Description
+        RSQLite::dbWriteTable(
+            conn = con,
+            name = "Description",
+            unique(description_data()),
+            overwrite = FALSE,
+            append = TRUE)
+        ## @ns-rse 2026-06-02 Debugging...
+        ## print("WHAT HAVE WE GOT IN THE DATABASE Description TABLE?")
+        ## query <- "SELECT * FROM Description"
+        ## print(RSQLite::dbGetQuery(conn = con, query))
+        ## Interactions
+        RSQLite::dbWriteTable(
+            conn = con,
+            name = "Interactions",
+            unique(interactions_data()),
+            overwrite = FALSE,
+            append = TRUE
+        )
         ## @ns-rse 2026-06-02 Debugging...
         ## print("WHAT HAVE WE GOT IN THE DATABASE Interactions TABLE?")
         ## query <- "SELECT * FROM Interactions"

--- a/lottie/R/server.R
+++ b/lottie/R/server.R
@@ -470,9 +470,7 @@ server <- function(input, output, session) {
             append = TRUE
         )
         ## @ns-rse 2026-06-08 Debugging...
-        ## print("WHAT HAVE WE GOT IN THE DATABASE Conditions TABLE?")
-        ## query <- "SELECT * FROM Conditions"
-        ## print(RSQLite::dbGetQuery(conn = con, query))
+        db_table_debug(conn = con, table = "Conditions")
         ## Composition
         RSQLite::dbWriteTable(
                      conn = con,
@@ -481,9 +479,7 @@ server <- function(input, output, session) {
                      overwrite = FALSE,
                      append = TRUE)
         ## @ns-rse 2026-06-02 Debugging...
-        ## print("WHAT HAVE WE GOT IN THE DATABASE Composition TABLE?")
-        ## query <- "SELECT * FROM Composition"
-        ## print(RSQLite::dbGetQuery(conn = con, query))
+        db_table_debug(conn = con, table = "Composition")
         ## Description
         RSQLite::dbWriteTable(
             conn = con,
@@ -492,9 +488,7 @@ server <- function(input, output, session) {
             overwrite = FALSE,
             append = TRUE)
         ## @ns-rse 2026-06-02 Debugging...
-        ## print("WHAT HAVE WE GOT IN THE DATABASE Description TABLE?")
-        ## query <- "SELECT * FROM Description"
-        ## print(RSQLite::dbGetQuery(conn = con, query))
+        db_table_debug(conn = con, table = "Description")
         ## Interactions
         RSQLite::dbWriteTable(
             conn = con,
@@ -504,9 +498,7 @@ server <- function(input, output, session) {
             append = TRUE
         )
         ## @ns-rse 2026-06-02 Debugging...
-        ## print("WHAT HAVE WE GOT IN THE DATABASE Interactions TABLE?")
-        ## query <- "SELECT * FROM Interactions"
-        ## print(RSQLite::dbGetQuery(conn = con, query))
+        db_table_debug(conn = con, table = "Interactions")
     })
     ## Download Raw Data
     output$download_raw_data <- shiny::downloadHandler(

--- a/lottie/R/ui.R
+++ b/lottie/R/ui.R
@@ -202,8 +202,7 @@ individual_inputs <- list(
 individual_card <- display_section(
   header = "Flock Composition",
   shiny::tableOutput("composition"),
-  shiny::helpText("When you have added all individuals submit your data. NB - Duplicate observations in the above table will be removed on submission."),
-  shiny::actionButton("submit_composition", label = "Submit all composition data")
+  shiny::helpText("When you have added all individuals submit your data. NB - Duplicate observations of ringed birds in the above table will be removed on submission.")
 )
 
 ## Flock description card
@@ -294,8 +293,14 @@ flock_inputs <- list(
 flock_card <- display_section(
   header = "Flocks",
   shiny::tableOutput("description"),
-  shiny::helpText("When you have described all flocks submit your data. NB - Duplicate observations in the above table will be removed on submission."),
-  shiny::actionButton("submit_description", label = "Submit all flock data")
+  shiny::helpText("When you have described all flocks submit your data. NB - Duplicate observations in the above table will be removed on submission.")
+)
+
+## Submit data to database
+submit_card <- display_section(
+    header = "Submit data",
+    shiny::helpText("When you have entered all data and are ready to submit it to the database click on the button below."),
+    shiny::actionButton("submit_all", label = "Submit all data")
 )
 
 ## Flock interaction card
@@ -348,8 +353,7 @@ interaction_inputs <- list(
 interaction_card <- display_section(
   header = "Flock Interactions",
   shiny::tableOutput("interactions"),
-  shiny::helpText("When you have added all interactions submit your data. NB - Duplicate observations in the above table will be removed on submission."),
-  shiny::actionButton("submit_interactions", label = "Submit all interaction data")
+  shiny::helpText("When you have added all interactions submit your data. NB - Duplicate observations in the above table will be removed on submission.")
 )
 
 ## Download card
@@ -482,23 +486,6 @@ sidebar_orig <- bslib::sidebar(
 ui <- bslib::page_sidebar(
     title = shiny::h1("Lottie - Long-tailed Tit Data Capture"),
     sidebar = sidebar_accordion,
-    ## ns-rse : This is using non-standard evaluation but I think its an old form, newer methods are lazyeval
-    ## (https://cran.r-project.org/web/packages/lazyeval/vignettes/lazyeval.html)
-    ## ns-rse 2026-05-12 : Consider switching to column-layout
-    ## https://rstudio.github.io/bslib/articles/column-layout/index.html
-    ## bslib::layout_column_wrap(
-    ##    width = "300px",
-    ##    height = 300,
-    ##    fixed_width = FALSE,
-    ##    heights_equal = "all",
-    # bslib::navset_card_underline(
-    #     title = "Flock Observations...",
-    #     bslib::nav_panel("GPS", gps_card),
-    #     bslib::nav_panel("Description", flock_card),
-    #     bslib::nav_panel("Composition", individual_card),
-    #     bslib::nav_panel("Interactions", interaction_card),
-    #     bslib::nav_panel("Download", download_card)
-    #     )
     bslib::navset_card_underline(
       bslib::nav_panel(
         "Observations",
@@ -506,7 +493,8 @@ ui <- bslib::page_sidebar(
         conditions_card,
         flock_card,
         individual_card,
-        interaction_card
+        interaction_card,
+        submit_card
       ),
       bslib::nav_panel(
         "Download",

--- a/lottie/R/ui.R
+++ b/lottie/R/ui.R
@@ -202,7 +202,7 @@ individual_inputs <- list(
 individual_card <- display_section(
   header = "Flock Composition",
   shiny::tableOutput("composition"),
-  shiny::helpText("When you have added all individuals submit your data. NB - Duplicate observations of ringed birds in the above table will be removed on submission.")
+  shiny::helpText("NB - Duplicate observations of ringed birds in the above table will be removed on submission.")
 )
 
 ## Flock description card
@@ -293,7 +293,7 @@ flock_inputs <- list(
 flock_card <- display_section(
   header = "Flocks",
   shiny::tableOutput("description"),
-  shiny::helpText("When you have described all flocks submit your data. NB - Duplicate observations in the above table will be removed on submission.")
+  shiny::helpText("NB - Duplicate observations in the above table will be removed on submission.")
 )
 
 ## Submit data to database
@@ -353,7 +353,7 @@ interaction_inputs <- list(
 interaction_card <- display_section(
   header = "Flock Interactions",
   shiny::tableOutput("interactions"),
-  shiny::helpText("When you have added all interactions submit your data. NB - Duplicate observations in the above table will be removed on submission.")
+  shiny::helpText("NB - Duplicate observations in the above table will be removed on submission.")
 )
 
 ## Download card

--- a/lottie/R/utils.R
+++ b/lottie/R/utils.R
@@ -484,4 +484,14 @@ extract_and_compress_data <- function(zip_file, conn, input) {
     ## TODO : Remove CSV files from system
 }
 
+#' Query a database table to check contents for debugging.
+#'
+#' @param conn Database connection.
+#' @param table str Name of table to query.
+db_table_debug <- function(conn, table) {
+    print(paste0("Checking table : "))
+    query <- paste0("SELECT * FROM ", table)
+    print(RSQLite::dbGetQuery(conn, query))
+}
+
 ## End of file


### PR DESCRIPTION
- GPS data is added to database on file upload
- Conditions(/metadata), Flock, Individual and Interactions are accumulated into dataframes and tables displayed
- Remove individual buttons for submitting each of these types of observation
- Add a "Submit data" card with a help and global "Submit all data" button which takes the aggregated data from these

Perhaps check my mental model is correct that...

- There is only ever GPX track per day of observations
- Multiple metadata is possible (conditions may change throughout the day e.g. start or stop raining, cloud over).
- Multiple flocks can be recorded
- Multiple individuals can be recorded
- Multiple interactions can be recorded

Its really whether there is only ever on GPX file per day I am unsure of. Based on the provided example files I think
this is the case but am unsure. Was there perhaps something mentioned in last weeks meeting about uploading multiple GPX
files?