### PR TITLE
feature: deduplicate ringed entries; make ring fields reactive

### DIFF
--- a/lottie/R/lookups.R
+++ b/lottie/R/lookups.R
@@ -213,7 +213,7 @@ colour_ring_df <- data.frame(
     "SpP*R", "SpPL", "SpR*R", "SpRL", "SpRR", "SpSnL", "SpUL", "SpUR", "SpW*R", "SpWR", "SpY*L", "SpY*R", "SpYR",
     "SrB*L", "SrB*R", "SrG*L", "SrG*R", "SrN*L", "SrN*R", "SrP*L", "SrP*R", "SrR*L", "SrR*R", "SrW*L", "SrW*R", "SrY*L",
     "SrY*R", "SyB*L", "SyB*R", "SyG*L", "SyN*L", "SyP*L", "SyP*R", "SyR*L", "SyR*R", "SyW*L", "SyW*R", "SyY*L", "SyY*R",
-    "TRL", "U", "UB*L", "UB*R", "UDL", "UDR", "UFL", "UFR", "UG*L", "UG*R", "UL", "UML", "UMR", "UN*R", "UNL", "UOL",
+    "TRL", "UB*L", "UB*R", "UDL", "UDR", "UFL", "UFR", "UG*L", "UG*R", "UL", "UML", "UMR", "UN*R", "UNL", "UOL",
     "UOR", "UP*L", "UP*R", "UPR", "UR*L", "UR*R", "USdL", "USdR", "USnL", "USnR", "USpL", "USpR", "UUL", "UUR", "UW*R",
     "UWL", "UY*L", "UYL", "UYR", "UbmL", "UbmR", "UgdL", "UgdR", "UgnR", "UmbL", "UmbR", "UngL", "UngR", "W*BL", "W*FL",
     "W*FR", "W*GR", "W*MR", "W*NL", "W*OR", "W*PL", "W*PR", "W*RR", "W*SdL", "W*SdR", "W*SgL", "W*SnL", "W*SnR",

--- a/lottie/R/lookups.R
+++ b/lottie/R/lookups.R
@@ -89,7 +89,7 @@ rings_df <- data.frame(
         "W*",
         "Y*"),
     description = c(
-        NA,
+        "None",
         "BTO",
         "Light blue (B)",
         "Dark blue (D)",

--- a/lottie/R/server.R
+++ b/lottie/R/server.R
@@ -279,7 +279,7 @@ server <- function(input, output, session) {
         update_certainty(ring_certainty, tag = "right_top", session)
         update_certainty(ring_certainty, tag = "right_bottom", session)
     })
-    ## Build a data frame of birds within a flock when the "Submit bird description" button is clicked
+    ## Build the dataframe/table of birds within a flock when the "Submit bird description" button is clicked
     composition_data <- shiny::reactiveVal(empty_dataframes$composition_data)
     shiny::observeEvent(input$add_composition, {
         composition_to_add <- rbind(composition_data(), data.frame(
@@ -324,6 +324,25 @@ server <- function(input, output, session) {
     #################################################################################
     ## Build a data frame of flock description when the "Submit flock description" button is clicked
     description_data <- shiny::reactiveVal(empty_dataframes$description_data)
+    ## Update flock size based on flock_type being `Pair` (2) or `Individual` (1)
+    flock_type <- shiny::reactive({
+        print("input$description_flock_type")
+        print(input$description_flock_type)
+        input$description_flock_type
+    })
+    shiny::observe({
+        if (flock_type() == "pair") {
+            shiny::updateNumericInput(session, "description_n_flock", value = 2)
+            shiny::updateNumericInput(session, "description_n_ringed", value = 2)
+        } else if (flock_type() == "individual") {
+          shiny::updateNumericInput(session, "description_n_flock", value = 1)
+          shiny::updateNumericInput(session, "description_n_ringed", value = 1)
+        } else {
+          shiny::updateNumericInput(session, "description_n_flock", value = 12)
+          shiny::updateNumericInput(session, "description_n_ringed", value = 12)
+        }
+    })
+    ## Build the dataframe/table of flock descriptions when the "Submit flock description" button is clicked
     shiny::observeEvent(input$add_description, {
         shiny::validate(
                    shiny::need(input$description_n_ringed <= input$description_n_flock,
@@ -370,6 +389,13 @@ server <- function(input, output, session) {
             exclude = c("description_flock_number"))
         lapply(tmp_inputs, shinyjs::reset)
         description_data(description_to_add)
+    })
+    ## Increment Flock numbers
+    flock_number <- shiny::reactive({
+        input$description_flock_number
+    })
+    shiny::observeEvent(input$add_description, {
+        shiny::updateNumericInput(session, "description_flock_number", value = flock_number() + 1)
     })
     ## The description table is returned and rendered on the page
     output$description <- shiny::renderTable(

--- a/lottie/R/server.R
+++ b/lottie/R/server.R
@@ -301,6 +301,15 @@ server <- function(input, output, session) {
             notes = input$composition_notes,
             stringsAsFactors = FALSE
         ))
+        ## Reset the input fields using shinyjs, we get the list of all ids that are to be reset from the reactive
+        ## function all_inputs(), this requires filtering all_inputs for those that start with composition_
+        ## then removing those we do not want to update (in this case composition_flock_number since we want to
+        ## increment that automatically)
+        tmp_inputs <- filter_inputs(
+            input=all_inputs(),
+            filter = "^composition_",
+            exclude = c("composition_flock_number"))
+        lapply(tmp_inputs, shinyjs::reset)
         composition_data(composition_to_add)
     })
     ## The composition table is returned and rendered on the page
@@ -351,6 +360,15 @@ server <- function(input, output, session) {
         to_add <- tidy_columns(df = to_add, expected_cols = as.list(other_species_df$code))
         description_to_add <- rbind(description_data(),
                                     to_add)
+        ## Reset the input fields using shinyjs, we get the list of all ids that are to be reset from the reactive
+        ## function all_inputs(), this requires filtering all_inputs for those that start with description_
+        ## then removing those we do not want to update (in this case description_flock_number since we want to
+        ## increment that automatically)
+        tmp_inputs <- filter_inputs(
+            input=all_inputs(),
+            filter = "^description_",
+            exclude = c("description_flock_number"))
+        lapply(tmp_inputs, shinyjs::reset)
         description_data(description_to_add)
     })
     ## The description table is returned and rendered on the page
@@ -380,6 +398,14 @@ server <- function(input, output, session) {
             tidyr::pivot_wider(names_from = type, values_from = present, values_fill = FALSE)
         to_add <- tidy_columns(df = to_add, expected_cols = as.list(interactions_df$code))
         interactions_to_add <- rbind(interactions_data(), to_add)
+        ## Reset the input fields using shinyjs, we get the list of all ids that are to be reset from the reactive
+        ## function all_inputs(), this requires filtering all_inputs for those that start with description_
+        ## then removing those we do not want to update (in this case interactions_flock_number since we want to
+        ## increment that automatically)
+        tmp_inputs <- filter_inputs(
+            input=all_inputs(),
+            filter = "^interactions_",
+            exclude = c("interactions_flock_a", "interactions_flock_b"))
         interactions_data(interactions_to_add)
     })
     ## The interaction table is returned and rendered on the page
@@ -443,7 +469,7 @@ server <- function(input, output, session) {
         )
         ## @ns-rse 2026-06-02 Debugging...
         db_table_debug(conn = con, table = "Interactions")
-        ## Reset the input and tables using shinyjs, we get the list of all ids that are to be reset from the reactive
+        ## Reset the input fields using shinyjs, we get the list of all ids that are to be reset from the reactive
         ## function all_inputs()
         lapply(all_inputs(), shinyjs::reset)
     })

--- a/lottie/R/server.R
+++ b/lottie/R/server.R
@@ -32,24 +32,27 @@ if (testing) {
     overwrite <- TRUE
     ## People
     RSQLite::dbWriteTable(
-                 conn = con,
-                 name = "Person",
-                 person_df,
-                 overwrite = overwrite)
+        conn = con,
+        name = "Person",
+        person_df,
+        overwrite = overwrite
+    )
 
     ## Other Species
     RSQLite::dbWriteTable(
-                 conn = con,
-                 name = "OtherSpecies",
-                 other_species_df,
-                 overwrite = overwrite)
+        conn = con,
+        name = "OtherSpecies",
+        other_species_df,
+        overwrite = overwrite
+    )
 
     ## Rings
     RSQLite::dbWriteTable(
-                 conn = con,
-                 name = "Rings",
-                 rings_df,
-                 overwrite = overwrite)
+        conn = con,
+        name = "Rings",
+        rings_df,
+        overwrite = overwrite
+    )
 
     ## Section
     RSQLite::dbWriteTable(
@@ -83,19 +86,20 @@ if (testing) {
             check.names = FALSE
         ),
         overwrite = overwrite
-        )
+    )
     ## GPS
     RSQLite::dbWriteTable(
         conn = con,
         name = "GPS",
         data.frame(
-             "time" = character(),
-             "lat" = numeric(),
-             "lon" = numeric(),
-             "ele" = numeric(),
-             "filename" = character(),
-             stringsAsFactors = FALSE,
-             check.names = FALSE),
+            "time" = character(),
+            "lat" = numeric(),
+            "lon" = numeric(),
+            "ele" = numeric(),
+            "filename" = character(),
+            stringsAsFactors = FALSE,
+            check.names = FALSE
+        ),
         overwrite = overwrite
     )
 } else {
@@ -114,25 +118,14 @@ if (testing) {
     sites_df <- RSQLite::dbGetQuery(con, query)
 }
 
+## Setup empty dataframes
+empty_dataframes <- create_empty_dataframes()
+
 server <- function(input, output, session) {
     #################################################################################
     ## Conditions                                                                  ##
     #################################################################################
-    conditions_data <- shiny::reactiveVal(data.frame(
-        user = character(),
-        date = character(),
-        start_time = character(),
-        end_time = character(),
-        sunny = character(),
-        partly_cloudy = character(),
-        cloudy_grey = character(),
-        foggy = character(),
-        windy = character(),
-        light_rain = character(),
-        really_rain = character(),
-        visibility = character(),
-        stringsAsFactors = FALSE
-    ))
+    conditions_data <- shiny::reactiveVal(empty_dataframes$conditions_data)
     shiny::observeEvent(input$submit_conditions, {
         ## ns-rse - Reshape the data to wide as weather column can have multiple values and these expand to long format
         ## data
@@ -287,26 +280,8 @@ server <- function(input, output, session) {
         update_certainty(ring_certainty, tag = "right_bottom", session)
     })
     ## Build a data frame of birds within a flock when the "Submit bird description" button is clicked
-    composition_data <- shiny::reactiveVal(data.frame(
-            date = character(),
-            time = character(),
-            flock_number = integer(),
-            ringed = character(),
-            colour_ring = character(),
-            certain = character(),
-            left_top= character(),
-            left_top_certain = character(),
-            left_bottom= character(),
-            left_bottom_certain = character(),
-            right_top = character(),
-            right_top_certain = character(),
-            right_bottom = character(),
-            right_bottom_certain = character(),
-            bto_ring_position = character(),
-            notes = character(),
-            stringsAsFactors = FALSE
-            ))
-   shiny::observeEvent(input$add_composition, {
+    composition_data <- shiny::reactiveVal(empty_dataframes$composition_data)
+    shiny::observeEvent(input$add_composition, {
         composition_to_add <- rbind(composition_data(), data.frame(
             date = as.character(input$composition_date),
             time = as.character(input$composition_time),
@@ -339,36 +314,7 @@ server <- function(input, output, session) {
     ## Flock Description                                                           ##
     #################################################################################
     ## Build a data frame of flock description when the "Submit flock description" button is clicked
-   description_data <- shiny::reactiveVal(data.frame(
-            date = character(),
-            start_time = character(),
-            end_time = character(),
-            flock_type = character(),
-            flock_number = integer(),
-            whole_flock = character(),
-            n_flock = integer(),
-            n_ringed = integer(),
-            section = character(),
-            mist_net = character(),
-            notes = character(),
-            blue_tit = logical(),
-            chiff_chaff = logical(),
-            chaffinch = logical(),
-            coal_tit = logical(),
-            dunnock = logical(),
-            goldcrest = logical(),
-            great_tit = logical(),
-            nuthatch = logical(),
-            robin = logical(),
-            siskin = logical(),
-            tree_creeper = logical(),
-            unknown_tit = logical(),
-            woodpecker = logical(),
-            wren = logical(),
-            willow_warbler = logical(),
-            stringsAsFactors = FALSE,
-            check.names = FALSE
-    ))
+    description_data <- shiny::reactiveVal(empty_dataframes$description_data)
     shiny::observeEvent(input$add_description, {
         shiny::validate(
                    shiny::need(input$description_n_ringed <= input$description_n_flock,
@@ -418,19 +364,7 @@ server <- function(input, output, session) {
     ## Interactions                                                                ##
     #################################################################################
     ## Build a data frame of interactions when the "Submit interaction" button is clocked
-    interactions_data <- shiny::reactiveVal(data.frame(
-            date = character(),
-            time = character(),
-            flock_a = integer(),
-            flock_b = integer(),
-            ## type = character(),
-            foraging_together = logical(),
-            a_chasing_b = logical(),
-            b_chasing_a = logical(),
-            close_but_not_interacting = logical(),
-            other = logical(),
-            notes = character(),
-            stringsAsFactors = FALSE))
+    interactions_data <- shiny::reactiveVal(empty_dataframes$interactions_data)
     shiny::observeEvent(input$add_interactions, {
         ## ns-rse - Reshape the data to wide as type column can have multiple
         ## values and are captured in long format
@@ -456,6 +390,14 @@ server <- function(input, output, session) {
         striped = TRUE)
 
     #################################################################################
+    ## Extract a list of all input id's                                            ##
+    #################################################################################
+    all_inputs <- shiny::reactive({
+        x <- shiny::reactiveValuesToList(input)
+        names(x)
+    })
+
+    #################################################################################
     ## Database submission                                                         ##
     #################################################################################
     ## Add data to SQLite database when the "Submit all data" button is pressed
@@ -473,11 +415,12 @@ server <- function(input, output, session) {
         db_table_debug(conn = con, table = "Conditions")
         ## Composition
         RSQLite::dbWriteTable(
-                     conn = con,
-                     name = "Composition",
-                     composition_data(),
-                     overwrite = FALSE,
-                     append = TRUE)
+            conn = con,
+            name = "Composition",
+            composition_data(),
+            overwrite = FALSE,
+            append = TRUE
+        )
         ## @ns-rse 2026-06-02 Debugging...
         db_table_debug(conn = con, table = "Composition")
         ## Description
@@ -486,7 +429,8 @@ server <- function(input, output, session) {
             name = "Description",
             unique(description_data()),
             overwrite = FALSE,
-            append = TRUE)
+            append = TRUE
+        )
         ## @ns-rse 2026-06-02 Debugging...
         db_table_debug(conn = con, table = "Description")
         ## Interactions
@@ -499,7 +443,13 @@ server <- function(input, output, session) {
         )
         ## @ns-rse 2026-06-02 Debugging...
         db_table_debug(conn = con, table = "Interactions")
+        ## Reset the input and tables using shinyjs, we get the list of all ids that are to be reset from the reactive
+        ## function all_inputs()
+        lapply(all_inputs(), shinyjs::reset)
     })
+
+
+
     ## Download Raw Data
     output$download_raw_data <- shiny::downloadHandler(
         filename = function() {

--- a/lottie/R/server.R
+++ b/lottie/R/server.R
@@ -252,6 +252,18 @@ server <- function(input, output, session) {
     #################################################################################
     ## Flock Composition                                                           ##
     #################################################################################
+    ringed <- shiny::reactive({input$composition_ringed})
+    shiny::observe({
+        if (ringed() == FALSE) {
+            update_rings_when_not_ringed(session)
+        }
+    })
+    colour_ring <- shiny::reactive({input$composition_colour_ring})
+    shiny::observe({
+        if (colour_ring() != "None") {
+            shiny::updateSelectInput(session,"composition_ringed", selected = TRUE)
+        }
+    })
     ## Extract ring colours from selection so they can be used to populate the `selectInput(..., choices=)` of the
     ## `colour_ring_inputs()` function
     selected_rings <- shiny::reactive({
@@ -278,6 +290,19 @@ server <- function(input, output, session) {
         update_certainty(ring_certainty, tag = "left_bottom", session)
         update_certainty(ring_certainty, tag = "right_top", session)
         update_certainty(ring_certainty, tag = "right_bottom", session)
+    })
+    ## Uncheck certainty if any of the individual ring certains are change to FALSE
+    left_top_certain <- shiny::reactive({input$composition_left_top_certain})
+    left_bottom_certain <- shiny::reactive({input$composition_left_bottom_certain})
+    right_top_certain <- shiny::reactive({input$composition_right_top_certain})
+    right_bottom_certain <- shiny::reactive({input$composition_right_bottom_certain})
+    shiny::observe({
+        if (left_top_certain() == FALSE |
+            left_bottom_certain() == FALSE |
+            right_top_certain() == FALSE |
+            right_bottom_certain() == FALSE ) {
+            shiny::updateCheckboxInput(session, "composition_certain", value = FALSE)
+        }
     })
     ## Build the dataframe/table of birds within a flock when the "Submit bird description" button is clicked
     composition_data <- shiny::reactiveVal(empty_dataframes$composition_data)
@@ -468,11 +493,13 @@ server <- function(input, output, session) {
         )
         ## @ns-rse 2026-06-08 Debugging...
         db_table_debug(conn = con, table = "Conditions")
-        ## Composition
+        ## Composition - we deduplicate ringed birds first (via deduplicate_flock())
+        composition_all <- composition_data()
+        composition_data_dedup <- deduplicate_flock(df = composition_all)
         RSQLite::dbWriteTable(
             conn = con,
             name = "Composition",
-            composition_data(),
+            composition_data_dedup,
             overwrite = FALSE,
             append = TRUE
         )

--- a/lottie/R/server.R
+++ b/lottie/R/server.R
@@ -253,16 +253,17 @@ server <- function(input, output, session) {
     ## Flock Composition                                                           ##
     #################################################################################
     ringed <- shiny::reactive({input$composition_ringed})
+    colour_ring <- shiny::reactive({input$composition_colour_ring})
     shiny::observe({
-        if (ringed() == FALSE) {
+        if (ringed() == FALSE || colour_ring() == "None" ) {
             update_rings_when_not_ringed(session)
         }
     })
-    colour_ring <- shiny::reactive({input$composition_colour_ring})
     shiny::observe({
         if (colour_ring() != "None") {
-            shiny::updateSelectInput(session,"composition_ringed", selected = TRUE)
-        }
+            shiny::updateSelectInput(session, "composition_ringed", selected = TRUE)
+        } else {
+           shiny::updateSelectInput(session, "composition_bto_ring_position", selected="None")}
     })
     ## Extract ring colours from selection so they can be used to populate the `selectInput(..., choices=)` of the
     ## `colour_ring_inputs()` function

--- a/lottie/R/server.R
+++ b/lottie/R/server.R
@@ -326,8 +326,6 @@ server <- function(input, output, session) {
     description_data <- shiny::reactiveVal(empty_dataframes$description_data)
     ## Update flock size based on flock_type being `Pair` (2) or `Individual` (1)
     flock_type <- shiny::reactive({
-        print("input$description_flock_type")
-        print(input$description_flock_type)
         input$description_flock_type
     })
     shiny::observe({
@@ -379,6 +377,11 @@ server <- function(input, output, session) {
         to_add <- tidy_columns(df = to_add, expected_cols = as.list(other_species_df$code))
         description_to_add <- rbind(description_data(),
                                     to_add)
+        ## Update available flocks based on added descriptions (used in composition and interactions)
+        flocks <- as.vector(description_to_add$flock_number)
+        shiny::updateSelectInput(session, "composition_flock_number", choices = flocks)
+        shiny::updateSelectInput(session, "interactions_flock_a", choices = flocks)
+        shiny::updateSelectInput(session, "interactions_flock_b", choices = flocks)
         ## Reset the input fields using shinyjs, we get the list of all ids that are to be reset from the reactive
         ## function all_inputs(), this requires filtering all_inputs for those that start with description_
         ## then removing those we do not want to update (in this case description_flock_number since we want to

--- a/lottie/R/ui.R
+++ b/lottie/R/ui.R
@@ -189,12 +189,12 @@ individual_inputs <- list(
   ),
   bslib::layout_column_wrap(
     simple_card("Left Leg...",
-                colour_ring_inputs(position = "lt", selected = ""),
-                colour_ring_inputs(position = "lb", selected = "")
+                colour_ring_inputs(position = "lt", selected = "None"),
+                colour_ring_inputs(position = "lb", selected = "None")
                 ),
     simple_card("Right Leg...",
-                colour_ring_inputs(position = "rt", selected = ""),
-                colour_ring_inputs(position = "rb", selected = "")
+                colour_ring_inputs(position = "rt", selected = "None"),
+                colour_ring_inputs(position = "rb", selected = "None")
                 ),
     fill = FALSE
   ),

--- a/lottie/R/ui.R
+++ b/lottie/R/ui.R
@@ -98,7 +98,7 @@ gps_inputs <- list(
   shiny::br(),
   shiny::fileInput(
     "gpx",
-    "Choose GPX File",
+    label = "Choose GPX File",
     multiple = FALSE,
     accept = c(".gpx")
   ),
@@ -130,7 +130,7 @@ individual_inputs <- list(
       class = "shiny-input-container bslib-gap-spacing",
       shinyTime::timeInput(
         "composition_time",
-        "Time : ",
+        label = "Time : ",
         seconds = FALSE,
         value = Sys.time()
       )
@@ -341,6 +341,7 @@ interaction_inputs <- list(
   ),
   shiny::checkboxGroupInput("interactions_type",
                      label = "Type of Interaction : ",
+                     selected = "a_chasing_b",
                      choices = split(interactions_df$code,
                                      interactions_df$description)),
   shiny::textInput("interactions_notes",
@@ -486,6 +487,8 @@ sidebar_orig <- bslib::sidebar(
 ui <- bslib::page_sidebar(
     title = shiny::h1("Lottie - Long-tailed Tit Data Capture"),
     sidebar = sidebar_accordion,
+    ## This allows use of shinyjs::reset() to reset fields on submission
+    shinyjs::useShinyjs(),
     bslib::navset_card_underline(
       bslib::nav_panel(
         "Observations",

--- a/lottie/R/ui.R
+++ b/lottie/R/ui.R
@@ -164,7 +164,7 @@ individual_inputs <- list(
         "composition_ringed",
         label = "Ringed : ",
         selected = "Yes",
-        choices = c("Yes" = "yes", "No" = "no")
+        choices = c("Yes" = TRUE, "No" = FALSE)
       ),
       shiny::selectInput(
         "composition_bto_ring_position",

--- a/lottie/R/ui.R
+++ b/lottie/R/ui.R
@@ -260,7 +260,7 @@ flock_inputs <- list(
     shiny::numericInput(
       "description_n_flock",
       label = "Flock Size : ",
-      min = 0,
+      min = 1,
       max = 60,
       value = 12,
       step = 1
@@ -268,7 +268,7 @@ flock_inputs <- list(
     shiny::numericInput(
       "description_n_ringed",
       label = "Number of Ringed Birds : ",
-      min = 0,
+      min = 1,
       max = 60,
       value = 12,
       step = 1

--- a/lottie/R/ui.R
+++ b/lottie/R/ui.R
@@ -136,14 +136,20 @@ individual_inputs <- list(
       )
     )
   ),
-  shiny::numericInput(
-    "composition_flock_number",
-    label = "Flock Number : ",
-    min = 1,
-    max = 60,
-    value = 1,
-    step = 1
+  shiny::selectInput(
+     "composition_flock_number",
+     label = "Flock Number : ",
+     selected = NULL,
+     choices = seq(1, 20)
   ),
+  ## shiny::numericInput(
+  ##   "composition_flock_number",
+  ##   label = "Flock Number : ",
+  ##   min = 1,
+  ##   max = 60,
+  ##   value = 1,
+  ##   step = 1
+  ## ),
   bslib::card_title("Rings"),
   shiny::helpText(
       "For details on reading rings see the document",
@@ -322,22 +328,34 @@ interaction_inputs <- list(
     )
   ),
   bslib::layout_column_wrap(
-    shiny::numericInput(
+    shiny::selectInput(
       "interactions_flock_a",
       label = "Flock A (numeric ID) : ",
-      min = 0,
-      max = 300,
-      value = 0,
-      step = 1
+       selected = NULL,
+       choices = seq(1, 20)
     ),
-    shiny::numericInput(
+    shiny::selectInput(
       "interactions_flock_b",
       label = "Flock B (numeric ID) : ",
-      min = 0,
-      max = 300,
-      value = 0,
-      step = 1
-    )
+       selected = NULL,
+       choices = seq(1, 20)
+    ),
+    ## shiny::numericInput(
+    ##   "interactions_flock_a",
+    ##   label = "Flock A (numeric ID) : ",
+    ##   min = 0,
+    ##   max = 300,
+    ##   value = 0,
+    ##   step = 1
+    ## ),
+    ## shiny::numericInput(
+    ##   "interactions_flock_b",
+    ##   label = "Flock B (numeric ID) : ",
+    ##   min = 0,
+    ##   max = 300,
+    ##   value = 0,
+    ##   step = 1
+    ## )
   ),
   shiny::checkboxGroupInput("interactions_type",
                      label = "Type of Interaction : ",

--- a/lottie/R/utils.R
+++ b/lottie/R/utils.R
@@ -582,7 +582,7 @@ create_empty_dataframes <- function() {
 
 #' Render a dataframe table as a Shiny.
 #'
-#' @param df Dataframe for rendering as table.
+#' @param df dataframe Dataframe for rendering as table.
 #' @param striped bool Whether the table should be striped or not (default `TRUE`).
 render_table <- function(df, striped = TRUE) {
         shiny::renderTable(
@@ -608,5 +608,35 @@ filter_inputs <- function(inputs, filter, exclude) {
     tmp_inputs <- inputs[stringr::str_detect(inputs, filter)]
     tmp_inputs[!(tmp_inputs %in% exclude)]
 }
+
+#' De-duplicate ringed entries from flock description.
+#'
+#' When entering data there should be no duplicated individuals in the flock with rings. Un-ringed birds are
+#' permissible, by virtue of sharing the characteristic of not having rings.
+#'
+#' @param df dataframe Dataframe for de-duplicating.
+deduplicate_flock <- function(df) {
+    rbind(
+        df |> dplyr::filter(ringed == FALSE),
+        df |> dplyr::filter(ringed == TRUE) |> unique()
+    )
+}
+
+#' Update ring component fields.
+#'
+#' This function is called when the `composition_ringed` field is changed to "No" (`FALSE`) and clears all ring fields
+#' so that no erroneous data is submitted.
+#'
+#' @param session The session to be updated.
+update_rings_when_not_ringed <- function(session) {
+    shiny::updateSelectInput(session, "composition_colour_ring", selected="None")
+    shiny::updateCheckboxInput(session, "composition_certain", value = FALSE)
+    for (tag in c("left_top", "left_bottom", "right_top", "right_bottom")) {
+        shiny::updateSelectInput(session, paste0("composition_", tag), selected = "None")
+        shiny::updateCheckboxInput(session, paste0("composition_", tag, "certain"), value = FALSE)
+    }
+    shiny::updateSelectInput(session, "composition_bto_ring_position", selected="None")
+}
+
 
 ## End of file

--- a/lottie/R/utils.R
+++ b/lottie/R/utils.R
@@ -206,8 +206,10 @@ extract_rings <- function(code, valid_codes, known_rings) {
     ## BTO ring is always on the other leg to coloured rings...
     if (rings$leg == "L") {
         rings$bto <- "R"
-    } else {
+    } else if (rings$leg == "R") {
         rings$bto <- "L"
+    } else {
+        rings$bto <- "None"
     }
     ## ...unless the recorded ring is "BTO L" or "BTO R" in which case there are no other rings other than the BTO on
     ## the indicated leg.

--- a/lottie/R/utils.R
+++ b/lottie/R/utils.R
@@ -330,14 +330,14 @@ update_all_rings <- function(rings, session) {        ## We again deal with PIT 
                 ## ns-rse 2026-06-23 - Debugging
                 ## print("PIT first")
                 update_ring(session, tag = "left_top", selected = rings$first)
-                update_ring(session, tag = "left_bottom", selected = "")
+                update_ring(session, tag = "left_bottom", selected = "None")
                 update_ring(session, tag = "right_top", selected = "BTO")
                 update_ring(session, tag = "right_bottom", selected = rings$second)
             } else {
                 ## ns-rse 2026-06-23 - Debugging
                 ## print("PIT second")
                 update_ring(session, tag = "left_top", selected = rings$second)
-                update_ring(session, tag = "left_bottom", selected = "")
+                update_ring(session, tag = "left_bottom", selected = "None")
                 update_ring(session, tag = "right_top", selected = rings$first)
                 update_ring(session, tag = "right_bottom", selected = "BTO")
             }
@@ -351,14 +351,14 @@ update_all_rings <- function(rings, session) {        ## We again deal with PIT 
                 update_ring(session, tag = "left_top", selected = "BTO")
                 update_ring(session, tag = "left_bottom", selected = rings$second)
                 update_ring(session, tag = "right_top", selected = rings$first)
-                update_ring(session, tag = "right_bottom", selected = "")
+                update_ring(session, tag = "right_bottom", selected = "None")
             } else {
                 ## ns-rse 2026-06-23 - Debugging
                 ## print("PIT second")
                 update_ring(session, tag = "left_top", selected = rings$first)
                 update_ring(session, tag = "left_bottom", selected = "BTO")
                 update_ring(session, tag = "right_top", selected = rings$second)
-                update_ring(session, tag = "right_bottom", selected = "")
+                update_ring(session, tag = "right_bottom", selected = "None")
             }
         }
     }
@@ -370,15 +370,15 @@ update_all_rings <- function(rings, session) {        ## We again deal with PIT 
             ## ns-rse 2026-06-23 - Debugging
             ## print("LEFT")
             update_ring(session, tag = "left_top", selected = "BTO")
-            update_ring(session, tag = "right_top", selected = "")
+            update_ring(session, tag = "right_top", selected = "None")
         } else {
             ## ns-rse 2026-06-23 - Debugging
             ## print("RIGHT")
-            update_ring(session, tag = "left_top", selected = "")
+            update_ring(session, tag = "left_top", selected = "None")
             update_ring(session, tag = "right_top", selected = "BTO")
         }
-        update_ring(session, tag = "left_bottom", selected = "")
-        update_ring(session, tag = "right_bottom", selected = "")
+        update_ring(session, tag = "left_bottom", selected = "None")
+        update_ring(session, tag = "right_bottom", selected = "None")
     }
     ## Finally set rings for birds with just colour (no PIT but BTO on opposite leg)
     else if (rings$leg == "L") {
@@ -388,22 +388,22 @@ update_all_rings <- function(rings, session) {        ## We again deal with PIT 
         update_ring(session, tag = "left_top", selected = rings$first)
         update_ring(session, tag = "left_bottom", selected = rings$second)
         update_ring(session, tag = "right_top", selected = "BTO")
-        update_ring(session, tag = "right_bottom", selected = "")
+        update_ring(session, tag = "right_bottom", selected = "None")
     } else if (rings$leg == "R") {
         ## ns-rse 2026-06-23 - Debugging
         ## print("NO PIT, JUST COLOUR")
         ## print("RIGHT")
         update_ring(session, tag = "left_top", selected = "BTO")
-        update_ring(session, tag = "left_bottom", selected = "")
+        update_ring(session, tag = "left_bottom", selected = "None")
         update_ring(session, tag = "right_top", selected = rings$first)
         update_ring(session, tag = "right_bottom", selected = rings$second)
     } else if(rings$code == "None"){
         ## ns-rse 2026-06-23 - Debugging
         ## print("NO RINGS")
-        update_ring(session, tag = "left_top", selected = "")
-        update_ring(session, tag = "left_bottom", selected = "")
-        update_ring(session, tag = "right_top", selected = "")
-        update_ring(session, tag = "right_bottom", selected = "")
+        update_ring(session, tag = "left_top", selected = "None")
+        update_ring(session, tag = "left_bottom", selected = "None")
+        update_ring(session, tag = "right_top", selected = "None")
+        update_ring(session, tag = "right_bottom", selected = "None")
     }
     update_ring(session, tag = "bto_ring_position", selected = rings$bto)
 }

--- a/lottie/R/utils.R
+++ b/lottie/R/utils.R
@@ -494,4 +494,100 @@ db_table_debug <- function(conn, table) {
     print(RSQLite::dbGetQuery(conn, query))
 }
 
+#' Setup empty dataframes for the different components
+create_empty_dataframes <- function() {
+    empty_df <- list()
+    empty_df$conditions <- data.frame(
+        user = character(),
+        date = character(),
+        start_time = character(),
+        end_time = character(),
+        sunny = character(),
+        partly_cloudy = character(),
+        cloudy_grey = character(),
+        foggy = character(),
+        windy = character(),
+        light_rain = character(),
+        really_rain = character(),
+        visibility = character(),
+        stringsAsFactors = FALSE
+    )
+    empty_df$composition_data <- data.frame(
+        date = character(),
+        time = character(),
+        flock_number = integer(),
+        ringed = character(),
+        colour_ring = character(),
+        certain = character(),
+        left_top = character(),
+        left_top_certain = character(),
+        left_bottom = character(),
+        left_bottom_certain = character(),
+        right_top = character(),
+        right_top_certain = character(),
+        right_bottom = character(),
+        right_bottom_certain = character(),
+        bto_ring_position = character(),
+        notes = character(),
+        stringsAsFactors = FALSE
+    )
+    empty_df$description_data <- data.frame(
+        date = character(),
+        start_time = character(),
+        end_time = character(),
+        flock_type = character(),
+        flock_number = integer(),
+        whole_flock = character(),
+        n_flock = integer(),
+        n_ringed = integer(),
+        section = character(),
+        mist_net = character(),
+        notes = character(),
+        blue_tit = logical(),
+        chiff_chaff = logical(),
+        chaffinch = logical(),
+        coal_tit = logical(),
+        dunnock = logical(),
+        goldcrest = logical(),
+        great_tit = logical(),
+        nuthatch = logical(),
+        robin = logical(),
+        siskin = logical(),
+        tree_creeper = logical(),
+        unknown_tit = logical(),
+        woodpecker = logical(),
+        wren = logical(),
+        willow_warbler = logical(),
+        stringsAsFactors = FALSE,
+        check.names = FALSE
+    )
+    empty_df$interactions_data <- data.frame(
+        date = character(),
+        time = character(),
+        flock_a = integer(),
+        flock_b = integer(),
+        foraging_together = logical(),
+        a_chasing_b = logical(),
+        b_chasing_a = logical(),
+        close_but_not_interacting = logical(),
+        other = logical(),
+        notes = character(),
+        stringsAsFactors = FALSE)
+    empty_df$gps_data <- data.frame(
+        Filename = character(),
+        Points = integer(),
+        Start=character(),
+        Finish = character())
+}
+
+#' Render a dataframe table as a Shiny.
+#'
+#' @param df Dataframe for rendering as table.
+#' @param striped bool Whether the table should be striped or not (default `TRUE`).
+render_table <- function(df, striped = TRUE) {
+        shiny::renderTable(
+            {df},
+            striped = striped
+        )}
+
 ## End of file

--- a/lottie/R/utils.R
+++ b/lottie/R/utils.R
@@ -590,4 +590,23 @@ render_table <- function(df, striped = TRUE) {
             striped = striped
         )}
 
+#' Filter a list of inputs for a subset and remove those that are to be excluded.
+#'
+#' We wish to reset input fields, to do so we need a list of labels used for ``input`` objects. This is provided by the
+#' ``all_inputs()`` function which returns _all_ inputs for a given session. We have three areas we wish to subset
+#' ``composition``, ``description``, and ``interactions`` but there are a small number of each that we do _not_ want to
+#' reset because they are either automatically incremented or take their values from other areas that have been input
+#' (e.g. when entering in ``composition_`` fields we wish to retain the ``flock_number`` that has been entered from the
+#' ``flock`` description; for interactions we wish the list of possible flocks under ``flock_a`` and ``flock_b`` to be
+#' based on the flocks that have been entered already.
+#'
+#' @param inputs list A list of strings which are to be filtered.
+#' @param filter str The string on which to filter, should be one of ``^composition_``, ``^description_``, and
+#' ``^interactions_``.
+#' @param exclude list A list of inputs to exclude.
+filter_inputs <- function(inputs, filter, exclude) {
+    tmp_inputs <- inputs[stringr::str_detect(inputs, filter)]
+    tmp_inputs[!(tmp_inputs %in% exclude)]
+}
+
 ## End of file


### PR DESCRIPTION
*NB* This is a stacked commit and should be merged after #37

- Deduplicates ringed entries prior to submission.
- Makes ring fields reactive, if `Ringed` is set to `No`(`FALSE`) then `Ring colour` is set to `None` and all other ring
  components are cleared. If a `Ring colour` is selected then `Ring` is set to `Yes`(`TRUE`)
- Unchecks the "global" `Certain` box if any of the individual (left/right top/bottom) `Certain` boxes are unchecked. It is
  possible to leave other rings as certain and only have one as uncertain.