### PR TITLE
refactor: Simplify reactivity and handling of 'Unlisted' Ring Colour

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -151,15 +151,16 @@ remove_none_column <- function(df) {
 #'
 #' @returns List of ring properties.
 #'
-#'  | Name     | Type    | Description                                              |
-#'  |:---------|:--------|:---------------------------------------------------------|
-#'  |`code`    | str     | The original full ring code.                             |
-#'  |`leg`     | str     | The leg denoted by the full rung code (the last letter). |
-#'  |`pit`     | boolean | Whether a "pit" ring is indicated.                       |
-#'  |`pit_pos` | str     | The position of the "pit" ring.                          |
-#'  |`bto`     | str     | The leg the BTO ring is on (inferred).                   |
-#'  |`first`   | str     | The first ring from the full ring code.                  |
-#'  |`second`  | str     | The second ring from the full ring code.                 |
+#'  | Name     | Type    | Description                                                                     |
+#'  |:---------|:--------|:--------------------------------------------------------------------------------|
+#'  |`code`    | str     | The original full ring code.                                                    |
+#'  |`ringed`  | boolean | Whether a bird is ringed or not (`FALSE` if `code == "None"`, otherwise `TRUE`) |
+#'  |`leg`     | str     | The leg denoted by the full ring code (the last letter).                        |
+#'  |`pit`     | boolean | Whether a "pit" ring is indicated.                                              |
+#'  |`pit_pos` | str     | The position of the "pit" ring.                                                 |
+#'  |`bto`     | str     | The leg the BTO ring is on (inferred).                                          |
+#'  |`first`   | str     | The first ring from the full ring code.                                         |
+#'  |`second`  | str     | The second ring from the full ring code.                                        |
 #'
 #' @export
 extract_rings <- function(code, valid_ring_combinations, valid_rings) {
@@ -169,6 +170,17 @@ extract_rings <- function(code, valid_ring_combinations, valid_rings) {
     }
     rings <- list()
     rings$code <- code
+    if (code == "None") {
+        rings$ringed <- FALSE
+        rings$leg <- ""
+        rings$pit <- FALSE
+        rings$bto <- "None"
+        rings$first <- ""
+        rings$second <- ""
+        return(rings)
+    } else {
+        rings$ringed <- TRUE
+    }
     ## Code is unlisted, return empty values, users should add their own
     if ((code == "Unlisted")) {
         rings$leg <- ""

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -277,10 +277,14 @@ server <- function(input, output, session) {
     #################################################################################
     ## Flock Composition                                                           ##
     #################################################################################
-    ringed <- shiny::reactive({input$composition_ringed})
+    ## We need to be able to see the values in the following and react conditional on their values
     colour_ring <- shiny::reactive({input$composition_colour_ring})
+    left_top <- shiny::reactive({input$composition_left_top})
+    left_bottom <- shiny::reactive({input$composition_left_bottom})
+    right_top <- shiny::reactive({input$composition_right_top})
+    right_bottom <- shiny::reactive({input$composition_right_bottom})
     shiny::observe({
-        if (ringed() == FALSE || colour_ring() == "None" ) {
+        if (colour_ring() == "None" ) {
             lottie::update_rings_when_not_ringed(session)
         }
     })
@@ -293,14 +297,13 @@ server <- function(input, output, session) {
     ## Extract ring colours from selection so they can be used to populate the `selectInput(..., choices=)` of the
     ## `colour_ring_inputs()` function
     selected_rings <- shiny::reactive({
-        ## We split the returned code using lottie::extract_rings(), this returns rings$leg, rings$top and rings$bottom
         rings <- lottie::extract_rings(
             code = input$composition_colour_ring,
             valid_ring_combinations = valid_ring_combinations_df$code,
             valid_rings = valid_rings_df$code)
         rings
     })
-    ## Having split the rings we can now use the leg and and assign the top/bottom to be selected automagically in the
+    ## Having split the rings we can now use the leg and assign the top/bottom to be selected automagically in the
     ## UI
     shiny::observe({
         rings <- selected_rings()
@@ -330,14 +333,20 @@ server <- function(input, output, session) {
             shiny::updateCheckboxInput(session, "composition_certain", value = FALSE)
         }
     })
+
     ## Build the dataframe/table of birds within a flock when the "Submit bird description" button is clicked
+    ## The 'ringed' and 'bto_ring_position' have been determined by lottie::extract_rings() and are stored in the
+    ## reactive object 'selected_rings()' which is a named list. This is done as it is easier programatically than
+    ## having reactive 'input$composition_ringed' and 'input$composition_bto_ring_position' and it simplifies the input
+    ## process for users who do not have to fill out fields for which it is possible to infer values.
     composition_data <- shiny::reactiveVal(empty_dataframes$composition_data)
     shiny::observeEvent(input$add_composition, {
-        composition_to_add <- rbind(composition_data(), data.frame(
+        ## We now set the `ringed` and `bto_ring_position` conditional on the selected rings
+        to_add <- data.frame(
             date = as.character(input$composition_date),
             time = as.character(format(input$composition_time, "%H:%M")),
             flock_number = input$composition_flock_number,
-            ringed = input$composition_ringed,
+            ringed = selected_rings()$ringed,
             colour_ring = input$composition_colour_ring,
             certain = input$composition_certain,
             left_top = input$composition_left_top,
@@ -348,10 +357,15 @@ server <- function(input, output, session) {
             right_top_certain = input$composition_right_top_certain,
             right_bottom = input$composition_right_bottom,
             right_bottom_certain = input$composition_right_bottom_certain,
-            bto_ring_position = input$composition_bto_ring_position,
             notes = input$composition_notes,
-            stringsAsFactors = FALSE
-        ))
+            stringsAsFactors = FALSE) |>
+            ## Add in the bto_ring_position conditional on the values of individual rings
+            dplyr::mutate(bto_ring_position = dplyr::case_when(left_top() == "BTO" ~ "L",
+                                                               left_bottom() == "BTO" ~ "L",
+                                                               right_top() == "BTO" ~ "R",
+                                                               right_bottom() == "BTO" ~ "R",
+                                                               .default = "None"))
+        composition_to_add <- rbind(composition_data(), to_add)
         ## Reset the input fields using shinyjs, we get the list of all ids that are to be reset from the reactive
         ## function all_inputs(), this requires filtering all_inputs for those that start with composition_
         ## then removing those we do not want to update (in this case composition_flock_number since we want to

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -179,14 +179,6 @@ individual_inputs <- list(
      selected = NULL,
      choices = seq(1, 20)
   ),
-  ## shiny::numericInput(
-  ##   "composition_flock_number",
-  ##   label = "Flock Number : ",
-  ##   min = 1,
-  ##   max = 60,
-  ##   value = 1,
-  ##   step = 1
-  ## ),
   bslib::card_title("Rings"),
   shiny::helpText(
       "For details on reading rings see the document",
@@ -196,20 +188,6 @@ individual_inputs <- list(
       "."),
   shiny::br(),
   bslib::layout_column_wrap(
-    list(
-      shiny::selectInput(
-        "composition_ringed",
-        label = "Ringed : ",
-        selected = "Yes",
-        choices = c("Yes" = TRUE, "No" = FALSE)
-      ),
-      shiny::selectInput(
-        "composition_bto_ring_position",
-        label = "BTO Ring Position : ",
-        selected = "None",
-        choices = c("None" = NA, "Left" = "L", "Right" = "R")
-      )
-    ),
     list(
       shiny::selectInput(
         "composition_colour_ring",

--- a/man/extract_rings.Rd
+++ b/man/extract_rings.Rd
@@ -23,6 +23,7 @@ possible that a \code{code} formed from \code{valid_rings} may not exist in \cod
 List of ring properties.\tabular{lll}{
    Name \tab Type \tab Description \cr
    \code{code} \tab str \tab The original full ring code. \cr
+   \code{ringed} \tab boolean \tab Whether a bird is ringed or not (\code{FALSE} if \code{code == "None"}, otherwise \code{TRUE} \cr
    \code{leg} \tab str \tab The leg denoted by the full rung code (the last letter). \cr
    \code{pit} \tab boolean \tab Whether a "pit" ring is indicated. \cr
    \code{pit_pos} \tab str \tab The position of the "pit" ring. \cr

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -32,26 +32,27 @@ patrick::with_parameters_test_that("Splitting of known codes is correct:",
     lottie::extract_rings(code = "gnBL", valid_ring_combinations = valid_ring_combinations, valid_rings = valid_rings),
     lottie::extract_rings(code = "ngDL", valid_ring_combinations = valid_ring_combinations, valid_rings = valid_rings),
     lottie::extract_rings(code = "ryFR", valid_ring_combinations = valid_ring_combinations, valid_rings = valid_rings),
-    lottie::extract_rings(code = "Unlisted", valid_ring_combinations = valid_ring_combinations, valid_rings = valid_rings),
+    lottie::extract_rings(code = "Unlisted", valid_ring_combinations = valid_ring_combinations, valid_rings =  valid_rings),
     lottie::extract_rings(code = "None", valid_ring_combinations = valid_ring_combinations, valid_rings = valid_rings)
   ),
   expected_rings = c(
-    list("code" = "bmrdR", "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "bm", "second" = "rd"),
-    list("code" = "SdnrL", "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "Sd", "second" = "nr"),
-    list("code" = "PonR", "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "P", "second" = "on"),
-    list("code" = "WY*L", "leg" = "L", "pit" = TRUE, "bto" = "R", "first" = "W", "second" = "Y*",
+    list("code" = "bmrdR", "ringed" = TRUE, "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "bm", "second" = "rd"),
+    list("code" = "SdnrL", "ringed" = TRUE, "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "Sd", "second" = "nr"),
+    list("code" = "PonR", "ringed" = TRUE, "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "P", "second" = "on"),
+    list("code" = "WY*L", "ringed" = TRUE, "leg" = "L", "pit" = TRUE, "bto" = "R", "first" = "W", "second" = "Y*",
          "pit_pos" = "second"),
-    list("code" = "Y*WL", "leg" = "L", "pit" = TRUE, "bto" = "R", "first" = "Y*", "second" = "W",
+    list("code" = "Y*WL", "ringed" = TRUE, "leg" = "L", "pit" = TRUE, "bto" = "R", "first" = "Y*", "second" = "W",
          "pit_pos" = "first"),
-    list("code" = "ryOR", "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "ry", "second" = "O"),
-    list("code" = "SgNL", "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "Sg", "second" = "N" ),
-    list("code" = "BDR", "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "B", "second" = "D"),
-    list( "code" = "BDL", "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "B", "second" = "D"),
-    list( "code" = "gnBL", "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "gn", "second" = "B"),
-    list( "code" = "ngDL", "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "ng", "second" = "D"),
-    list( "code" = "ryFR", "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "ry", "second" = "F"),
-    list( "code" = "Unlisted", "leg" = "", "pit" = FALSE, "bto" = "", "first" = "", "second" = ""),
-    list( "code" = "None", "leg" = "", "pit" = FALSE, "bto" = "None", "first" = "", "second" = "")
+    list("code" = "ryOR", "ringed" = TRUE, "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "ry", "second" = "O"),
+    list("code" = "SgNL", "ringed" = TRUE, "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "Sg", "second" = "N" ),
+    list("code" = "BDR", "ringed" = TRUE, "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "B", "second" = "D"),
+    list("code" = "BDL", "ringed" = TRUE, "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "B", "second" = "D"),
+    list("code" = "gnBL", "ringed" = TRUE, "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "gn", "second" = "B"),
+    list("code" = "ngDL", "ringed" = TRUE, "leg" = "L", "pit" = FALSE, "bto" = "R", "first" = "ng", "second" = "D"),
+    list("code" = "ryFR", "ringed" = TRUE, "leg" = "R", "pit" = FALSE, "bto" = "L", "first" = "ry", "second" = "F"),
+    ## When Unlisted users enter values as we can not extract anything
+    list("code" = "Unlisted", "ringed" = TRUE, "leg" = "", "pit" = FALSE, "bto" = "", "first" = "", "second" = "") ,
+    list("code" = "None", "ringed" = FALSE, "leg" = "", "pit" = FALSE, "bto" = "None", "first" = "", "second" = "")
   ),
   .test_name = c(
       "5-character right leg",
@@ -67,7 +68,7 @@ patrick::with_parameters_test_that("Splitting of known codes is correct:",
       "Split ring check (ngDL), was originally incorrectly split",
       "Split ring check (ryFR), was originally incorrectly split",
       "Unlisted returns missing/NA",
-      "None returns missing/NA"
+      "None returns FALSE/''/NA"
   )
 )
 


### PR DESCRIPTION
This had me banging my head on the table for ages trying to get the reactivity we had in place with all the boxes to work, in the end I gave up and thought about it from a different angle and came up with this solution which removes code in some places (always a good thing in my opinion) at the cost of adding some more internal logic to derive values conditionally (but I think this is clearer to understand, and as noted makes it easier for users).

This commit removes the `input$composition_ringed` and and `input$composition_bto_ring_position` from the UI (these were both `shiny::selectInput()` elements).

Both were fields that were being inferred and updated using reactive logic (changing a field in response to a change in another field), but because of this they are essentially redundant and @ns-rse found that it was introducing some circular logic that made updating fields awkward because of the interdependency.

`ringed`

Instead we determine `ringed`  using the existing logic in `lottie::extract_rings()` which determines the BTO and populates the `top/bottom` / `left/right` as well boolean `ringed`. These are stored in the reactive object `selected_rings()` which is a named list.

We watch the values of `top_left()` / `bottom_left()` / `top_right()` / `bottom_right()` and use these values to populate the `bto_ring_position` in the data frame via `dplyr::mutate()` before appending. I could not get the reactivity to work any other way, because its not possible to update `rings()$bto` conditional on these and use that directly.

As well as making this easier programatically than it also simplifies the input process for users who do not have to fill out fields for which it is possible to infer values and which are changing based on other values.

