### PR TITLE
fix: Allow submission of partial data

### DIFF
--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -528,49 +528,54 @@ server <- function(input, output, session) {
   #################################################################################
   ## Add data to SQLite database when the "Submit all data" button is pressed
   shiny::observeEvent(input$submit_all, {
-    ## GPS data is submitted on file upload
+    ## GPS data is submitted on file upload, the rest is uploaded on input$submit_all
     ## Conditions/metadata
-    RSQLite::dbWriteTable(
-      conn = con,
-      name = "Conditions",
-      unique(conditions_data()),
-      overwrite = FALSE,
-      append = TRUE
-    )
+    if (!is.null(conditions_data())) {
+      RSQLite::dbWriteTable(
+        conn = con,
+        name = "Conditions",
+        unique(conditions_data()),
+        overwrite = FALSE,
+        append = TRUE)
+    }
     ## @ns-rse 2026-06-08 Debugging...
-    db_table_debug(conn = con, table = "Conditions")
+    ## db_table_debug(conn = con, table = "Conditions")
     ## Composition - we deduplicate ringed birds first (via deduplicate_flock())
-    composition_all <- composition_data()
-    composition_data_dedup <- lottie::deduplicate_flock(df = composition_all)
-    RSQLite::dbWriteTable(
-      conn = con,
-      name = "Composition",
-      composition_data_dedup,
-      overwrite = FALSE,
-      append = TRUE
-    )
+    if (!is.null(composition_data())) {
+      composition_all <- composition_data()
+      composition_data_dedup <- lottie::deduplicate_flock(df = composition_all)
+      RSQLite::dbWriteTable(
+        conn = con,
+        name = "Composition",
+        composition_data_dedup,
+        overwrite = FALSE,
+        append = TRUE
+      )
+    }
     ## @ns-rse 2026-06-02 Debugging...
-    db_table_debug(conn = con, table = "Composition")
+    ## db_table_debug(conn = con, table = "Composition")
     ## Description
-    RSQLite::dbWriteTable(
-      conn = con,
-      name = "Description",
-      unique(description_data()),
-      overwrite = FALSE,
-      append = TRUE
-    )
+    if (!is.null(description_data())) {
+      RSQLite::dbWriteTable(
+        conn = con,
+        name = "Description",
+        unique(description_data()),
+        overwrite = FALSE,
+        append = TRUE)
+    }
     ## @ns-rse 2026-06-02 Debugging...
-    db_table_debug(conn = con, table = "Description")
+    ## db_table_debug(conn = con, table = "Description")
     ## Interactions
-    RSQLite::dbWriteTable(
-      conn = con,
-      name = "Interactions",
-      unique(interactions_data()),
-      overwrite = FALSE,
-      append = TRUE
-    )
+    if (!is.null(interactions_data() |> nrow())) {
+      RSQLite::dbWriteTable(
+        conn = con,
+        name = "Interactions",
+        unique(interactions_data()),
+        overwrite = FALSE,
+        append = TRUE)
+    }
     ## @ns-rse 2026-06-02 Debugging...
-    db_table_debug(conn = con, table = "Interactions")
+    ## db_table_debug(conn = con, table = "Interactions")
     ## Reset the input fields using shinyjs, we get the list of all ids that are to be reset from the reactive
     ## function all_inputs()
     lapply(all_inputs(), shinyjs::reset)

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -277,13 +277,13 @@ server <- function(input, output, session) {
   left_top <- shiny::reactive({
     input$composition_left_top
   })
-  if (colour_ring() == "None") {
-    lottie::update_rings_when_not_ringed(session)
-  }
+  left_bottom <- shiny::reactive({
+    input$composition_left_bottom
+  })
   right_top <- shiny::reactive({
     input$composition_right_top
   })
-    right_bottom <- shiny::reactive({
+  right_bottom <- shiny::reactive({
     input$composition_right_bottom
   })
   shiny::observe({


### PR DESCRIPTION
Closes #39

We make the section that is reactive to `Submit All` only attempt to enter data to the database if the given data frame is not missing (aka `NULL`).

This allows observations of...

- flocks to be recorded without any interactions
- missing GPS (although that is submitted elsewhere on file upload!)
- missing conditions

..and such like.

Linting introduced a mistake, this pull request reverts it.