### PR TITLE
feature: clear tables after submisson

### DIFF
--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -565,6 +565,8 @@ server <- function(input, output, session) {
     ## Reset the input fields using shinyjs, we get the list of all ids that are to be reset from the reactive
     ## function all_inputs()
     lapply(all_inputs(), shinyjs::reset)
+    ## Refresh the page which clears the existing tables
+    shinyjs::refresh()
   })
 
 


### PR DESCRIPTION
Closes #62

Clears the able via `shinyjs::refresh()`.

In testing I noticed that the `description_flock_number` is not reset, but that is by design as it is explicitly
excluded.