### PR TITLE
Ensure that selected flock is retained when adjusting flock A/flock B choices

### DIFF
--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -482,14 +482,16 @@ server <- function(input, output, session) {
     shiny::updateSelectInput(
       session,
       "interactions_flock_b",
-      choices = flocks[flocks != flock_a()])
+      choices = flocks[flocks != flock_a()],
+      selected = flock_b())
   })
   shiny::observeEvent(input$interactions_flock_b, {
     flocks <- as.list(description_data()$flock_number)
     shiny::updateSelectInput(
       session,
       "interactions_flock_a",
-      choices = flocks[flocks != flock_b()])
+      choices = flocks[flocks != flock_b()],
+      selected = flock_a())
   })
   ## Build a data frame of interactions when the "Submit interaction" button is clocked
   interactions_data <- shiny::reactiveVal(empty_dataframes$interactions_data)


### PR DESCRIPTION
I think this PR should fix the erratic behaviour when updating Flock A/Flock B lists. The currently selected value of the updated list is retained (if available in the new list of choices) and therefore there is no change event triggered on the other list.