### PR TITLE
ui: Add a banner to be displayed if Shiny app is in testing mode

### DIFF
--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -495,7 +495,7 @@ sidebar_orig <- bslib::sidebar(
   !!!conditions_inputs
 )
 
-testing_banner = NULL
+testing_banner <- NULL
 if (Sys.getenv("LOTTIES_TESTING")) {
     testing_banner <- shiny::div(class="p-3 bg-dark rounded-3 border text-center", "TESTING MODE")
 }

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -495,11 +495,17 @@ sidebar_orig <- bslib::sidebar(
   !!!conditions_inputs
 )
 
+testing_banner = NULL
+if (Sys.getenv("LOTTIES_TESTING")) {
+    testing_banner <- shiny::div(class="p-3 bg-dark rounded-3 border text-center", "TESTING MODE")
+}
+
 ui <- bslib::page_sidebar(
   title = shiny::h1("Lottie - Long-tailed Tit Data Capture"),
   sidebar = sidebar_accordion,
   ## This allows use of shinyjs::reset() to reset fields on submission
   shinyjs::useShinyjs(),
+  testing_banner,
   bslib::navset_card_underline(
     bslib::nav_panel(
       "Observations",


### PR DESCRIPTION
Uses the `LOTTIES_TESTING` R environment variable to determine whether the Shiny app is in testing mode and displays a banner accordingly.

Assumes that we will use the same environment variable to switch between modes in server.R.

I've kept the message displayed simple for now.