### PR TITLE
set launch.browser = FALSE

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,4 +1,7 @@
 ## Shiny options
-options(shiny.autoreload = TRUE,
-        shiny.port = 3781,
-        shiny.trace = TRUE)
+options(
+    shiny.autoreload = TRUE,
+    shiny.launch.browser = FALSE,
+    shiny.port = 3781,
+    shiny.trace = TRUE
+)

--- a/inst/lotties.service
+++ b/inst/lotties.service
@@ -21,7 +21,7 @@ Type=simple
 Restart=always
 RestartSec=1
 User=lotties
-ExecStart=nohup Rscript -e "devtools::load_all(path='/home/lotties/lotties/')" -e "shiny::runApp('/home/lotties/lotties/inst/shiny', port = ****, host = '###.###.###.###')" > /home/lotties/log/lotties.log 2>&1 &
+ExecStart=nohup Rscript -e "devtools::load_all(path='/home/lotties/lotties/')" -e "shiny::runApp('/home/lotties/lotties/inst/shiny', port = ****, host = '###.###.###.###', launch.browser = FALSE)" > /home/lotties/log/lotties.log 2>&1 &
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It is possible, but unlikely, that when we launch Shiny the lack of a browser is causing errors (see notes in #75).

We therefore add `launch.browser = FALSE` to the systemd service file (a copy of which resides in `inst/lotties.service`
for reference) and to `.Rprofile`.

The option has been added to the service file on the Virtual Machine by @ns-rse.