### PR TITLE
Ensure environment variables are loaded in systemd service

### DIFF
--- a/inst/lotties.service
+++ b/inst/lotties.service
@@ -21,6 +21,7 @@ Type=simple
 Restart=always
 RestartSec=1
 User=lotties
+WorkingDirectory=/home/lotties/lotties
 ExecStart=nohup Rscript -e "devtools::load_all(path='/home/lotties/lotties/')" \
                         # Uncomment the following line to get tracebacks when errors occur
                         # -e "options(shiny.fullstacktrace = TRUE, shiny.sanitize.errors = FALSE)" \

--- a/inst/lotties.service
+++ b/inst/lotties.service
@@ -21,7 +21,10 @@ Type=simple
 Restart=always
 RestartSec=1
 User=lotties
-ExecStart=nohup Rscript -e "devtools::load_all(path='/home/lotties/lotties/')" -e "shiny::runApp('/home/lotties/lotties/inst/shiny', port = ****, host = '###.###.###.###', launch.browser = FALSE)" > /home/lotties/log/lotties.log 2>&1 &
+ExecStart=nohup Rscript -e "devtools::load_all(path='/home/lotties/lotties/')" \
+                        # Uncomment the following line to get tracebacks when errors occur
+                        # -e "options(shiny.fullstacktrace = TRUE, shiny.sanitize.errors = FALSE)" \
+                        -e "shiny::runApp('/home/lotties/lotties/inst/shiny', port = ****, host = '###.###.###.###', launch.browser = FALSE)" > /home/lotties/log/lotties.log 2>&1 &
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes #75

- We explicitly set the `WorkingDirectory` for the systemd unit service defined in `lotties.serice` to be
  `/home/lotties/lotties`. This means the `.Renviron` file is loaded and `LOTTIES_TESTING` variable is   available for
  assessment as to whether to show the banner.
- Split the `Rscript` invocation over multiple lines and add a commented line which can be uncommented to allow
  debugging output when there is an error in the server.